### PR TITLE
Erases output dir on startup

### DIFF
--- a/src/articulation_downloader/grab_PDFs.py
+++ b/src/articulation_downloader/grab_PDFs.py
@@ -4,6 +4,15 @@ import requests
 import os
 
 def grabPDFs(university, major):
+    ROOT_DIR = os.path.dirname(os.path.abspath("main.py"))
+    output_path = os.path.join(ROOT_DIR, 'articulation_downloader', 'outputs')
+    
+    # delete any files in the outputs directory
+    for filename in os.listdir(output_path):
+        file_path = os.path.join(output_path, filename)
+        if os.path.isfile(file_path):  
+            os.remove(file_path)
+            
     institutions_url = urllib.request.urlopen("https://assist.org/api/institutions")
     institutions = json.load(institutions_url)
     id = None
@@ -35,9 +44,6 @@ def grabPDFs(university, major):
                     download_url = 'https://assist.org/api/artifacts/' + str(key)
                     response = requests.get(download_url, allow_redirects=True)
                     if response.status_code == 200:
-                        ROOT_DIR = os.path.dirname(os.path.abspath("main.py"))
-                        
-                        output_path = os.path.join(ROOT_DIR, 'articulation_downloader', 'outputs')
                         if not os.path.exists(output_path):
                             os.makedirs(output_path)
                         pdf = open(output_path + "\pdf" + str(key) + ".pdf", 'wb')

--- a/src/main.py
+++ b/src/main.py
@@ -11,10 +11,12 @@ import click
               help='The course you wish to take.')
 
 def find_colleges(university, major, course):
+  print("Downloading Agreements...")
   grabPDFs(university, major)
+  print("Finding Applicable colleges...")
   lis = courseList(course)
   print(lis)
-  print(len(lis))
+  print("There were " + str(len(lis)) + " colleges with this course.")
         
 if __name__ == '__main__':
     find_colleges()


### PR DESCRIPTION
Any files in the outputs directory are deleted before the program starts downloading agreements. 